### PR TITLE
Fix mix archive.install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-    mix archive.install git git@github.com:michalmuskala/decompile.git
+    mix archive.install github michalmuskala/decompile
 
 ## Usage
 


### PR DESCRIPTION
I was getting this error:

```console
$ mix archive.install git git@github.com:michalmuskala/decompile.git
* Getting new package (git@github.com:michalmuskala/decompile.git)
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
** (Mix) Command "git --git-dir=.git fetch --force --quiet --progress" failed
```